### PR TITLE
docs(readme): add archival notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+> [!NOTE]
+> This repository is not being updated actively.  Some of these materials may still be useful as reference; other content may be out of date.
+
+---
+
 > By contributing to this project, you agree to abide by our [Code of Conduct](https://github.com/freedomofpress/.github/blob/main/CODE_OF_CONDUCT.md).
 
 <img src="http://boxesandarrows.com/files/banda/uxdesign-planning-is/image_4_H_Maassen_honeycomb.jpg" alt="Morville's Honeycomb" width="300">


### PR DESCRIPTION
In the March 19 team meeting we decide we would add an archival notice to this repository's but not actually archive the GitHub project, which would make it read-only.